### PR TITLE
design:시험결과창 디자인 개선 및 기타 컴포넌트 이름 수정

### DIFF
--- a/src/components/Modal/ExamModal.styled.ts
+++ b/src/components/Modal/ExamModal.styled.ts
@@ -19,7 +19,8 @@ export const ModalContainer = styled.div`
   box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1);
   text-align: center;
   width: 112.5rem;
-  max-height: 80%;
+
+  max-height: 90%; // 기존 80%
   display: flex;
   flex-direction: column;
 `;
@@ -51,6 +52,7 @@ export const ModalCloseButton = styled.button`
 export const ModalContent = styled.div`
   flex: 1;
   overflow-y: auto;
+  overflow-x: hidden;
   max-height: 60%;
 `;
 
@@ -58,41 +60,31 @@ export const PartArea = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  p {
+
+  p.partInfo {
     width: 100%;
+    height: 4rem;
+    line-height: 4rem;
     align-self: flex-start;
+
     text-align: left;
     font-size: 2rem;
     font-weight: 700;
-    padding: 0 0 0.5rem 1.5rem;
+    padding: 0 0 0 1.5rem;
+    /* padding: 0 0 0.5rem 1.5rem; */
     border-bottom: solid #b9b9b9 0.125rem;
+    /* background-color: gray; */
+    background-color: white; // 배경색이 없으면 투명해서 안되는 것처럼 보임
+
+    position: sticky;
+    top: 0; // 최상단에 도달하면 멈춤
+    z-index: 10;
+    margin: 0;
   }
 `;
 
-export const QuestionBox = styled.div`
-  width: 87.5rem;
-  height: 22rem;
-  border-radius: 1rem;
-  background: white;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  box-shadow: 4px 4px 16px 6px rgba(0, 0, 0, 0.25);
-  margin: 1rem 0 10rem 0;
-`;
-
-export const QuestionTitle = styled.div`
-  margin: 2rem;
-  font-family: Roboto;
-  font-size: 1.75rem;
-  font-weight: 700;
-`;
-
-export const QuestionText = styled.div`
-  padding: 0 3rem 0 3rem;
-  font-family: Roboto;
-  font-size: 1.75rem;
-  font-style: normal;
-  font-weight: 400;
-  text-align: start;
+// 여기부터 새로 만듦
+export const ResultArea = styled.div`
+  margin-top: 2.5rem;
+  margin-bottom: 12rem;
 `;

--- a/src/components/Modal/ExamModal.tsx
+++ b/src/components/Modal/ExamModal.tsx
@@ -7,16 +7,19 @@ import {
   ModalCloseButton,
   ModalTitleArea,
   PartArea,
-  QuestionBox,
-  QuestionTitle,
-  QuestionText,
+  ResultArea,
 } from "./ExamModal.styled";
+import PassageBody from "../PassageBody";
+import ScoreBody from "../ScoreBody";
 
 interface ExamModalProps {
   isOpen: boolean;
   onClose: () => void;
   examDate: string | null;
 }
+
+const textContent =
+  "Welcome to the Boston International Airport. Your check-in process will take ten to fifteen minutes. In order to speed up the process, please have your identification and boardingpass ready as you approach the counter. Also, please make sure your luggage is labeled with your name, address and telephone number.";
 
 const ExamModal: React.FC<ExamModalProps> = ({ isOpen, onClose, examDate }) => {
   if (!isOpen) return null;
@@ -42,129 +45,185 @@ const ExamModal: React.FC<ExamModalProps> = ({ isOpen, onClose, examDate }) => {
         </ModalTitleArea>
         <ModalContent>
           <PartArea>
-            <p>Part1</p>
-            <QuestionBox>
-              <QuestionTitle>Question 1 of 11</QuestionTitle>
-              <QuestionText>
-                Welcome to the Boston International Airport. Your check-in
-                process will take ten to fifteen minutes. In order to speed up
-                the process, please have your identification and boardingpass
-                ready as you approach the counter. Also, please make sure your
-                luggage is labeled with your name, address and telephone number.
-              </QuestionText>
-            </QuestionBox>
-            <QuestionBox>
-              <QuestionTitle>Question 2 of 11</QuestionTitle>
-              <QuestionText>
-                Welcome to the Boston International Airport. Your check-in
-                process will take ten to fifteen minutes. In order to speed up
-                the process, please have your identification and boardingpass
-                ready as you approach the counter. Also, please make sure your
-                luggage is labeled with your name, address and telephone number.
-              </QuestionText>
-            </QuestionBox>
+            <div></div>
+            <p className="partInfo">Part1</p>
+            <ResultArea>
+              <PassageBody
+                text={textContent}
+                isScoring={true}
+                questionNum={1}
+                totalQuestions={11}
+              />
+              <ScoreBody
+                totalScore={86}
+                accuracy={80}
+                completeness={60}
+                fluency={85}
+                prosody={70}
+              />
+            </ResultArea>
+            <ResultArea>
+              <PassageBody
+                text={textContent}
+                isScoring={true}
+                questionNum={2}
+                totalQuestions={11}
+              />
+              <ScoreBody
+                totalScore={86}
+                accuracy={80}
+                completeness={60}
+                fluency={85}
+                prosody={70}
+              />
+            </ResultArea>
           </PartArea>
           <PartArea>
-            <p>Part2</p>
-            <QuestionBox>
-              <QuestionTitle>Question 3 of 11</QuestionTitle>
-              <QuestionText>
-                Welcome to the Boston International Airport. Your check-in
-                process will take ten to fifteen minutes. In order to speed up
-                the process, please have your identification and boardingpass
-                ready as you approach the counter. Also, please make sure your
-                luggage is labeled with your name, address and telephone number.
-              </QuestionText>
-            </QuestionBox>
-            <QuestionBox>
-              <QuestionTitle>Question 4 of 11</QuestionTitle>
-              <QuestionText>
-                Welcome to the Boston International Airport. Your check-in
-                process will take ten to fifteen minutes. In order to speed up
-                the process, please have your identification and boardingpass
-                ready as you approach the counter. Also, please make sure your
-                luggage is labeled with your name, address and telephone number.
-              </QuestionText>
-            </QuestionBox>
+            <p className="partInfo">Part2</p>
+            <ResultArea>
+              <PassageBody
+                text={textContent}
+                isScoring={true}
+                questionNum={3}
+                totalQuestions={11}
+              />
+              <ScoreBody
+                totalScore={86}
+                accuracy={80}
+                completeness={60}
+                fluency={85}
+                prosody={70}
+              />
+            </ResultArea>
+            <ResultArea>
+              <PassageBody
+                text={textContent}
+                isScoring={true}
+                questionNum={4}
+                totalQuestions={11}
+              />
+              <ScoreBody
+                totalScore={86}
+                accuracy={80}
+                completeness={60}
+                fluency={85}
+                prosody={70}
+              />
+            </ResultArea>
           </PartArea>
           <PartArea>
-            <p>Part3</p>
-            <QuestionBox>
-              <QuestionTitle>Question 5 of 11</QuestionTitle>
-              <QuestionText>
-                Welcome to the Boston International Airport. Your check-in
-                process will take ten to fifteen minutes. In order to speed up
-                the process, please have your identification and boardingpass
-                ready as you approach the counter. Also, please make sure your
-                luggage is labeled with your name, address and telephone number.
-              </QuestionText>
-            </QuestionBox>
-            <QuestionBox>
-              <QuestionTitle>Question 6 of 11</QuestionTitle>
-              <QuestionText>
-                Welcome to the Boston International Airport. Your check-in
-                process will take ten to fifteen minutes. In order to speed up
-                the process, please have your identification and boardingpass
-                ready as you approach the counter. Also, please make sure your
-                luggage is labeled with your name, address and telephone number.
-              </QuestionText>
-            </QuestionBox>
-            <QuestionBox>
-              <QuestionTitle>Question 7 of 11</QuestionTitle>
-              <QuestionText>
-                Welcome to the Boston International Airport. Your check-in
-                process will take ten to fifteen minutes. In order to speed up
-                the process, please have your identification and boardingpass
-                ready as you approach the counter. Also, please make sure your
-                luggage is labeled with your name, address and telephone number.
-              </QuestionText>
-            </QuestionBox>
+            <p className="partInfo">Part3</p>
+            <ResultArea>
+              <PassageBody
+                text={textContent}
+                isScoring={true}
+                questionNum={5}
+                totalQuestions={11}
+              />
+              <ScoreBody
+                totalScore={86}
+                accuracy={80}
+                completeness={60}
+                fluency={85}
+                prosody={70}
+              />
+            </ResultArea>
+            <ResultArea>
+              <PassageBody
+                text={textContent}
+                isScoring={true}
+                questionNum={6}
+                totalQuestions={11}
+              />
+              <ScoreBody
+                totalScore={86}
+                accuracy={80}
+                completeness={60}
+                fluency={85}
+                prosody={70}
+              />
+            </ResultArea>
+            <ResultArea>
+              <PassageBody
+                text={textContent}
+                isScoring={true}
+                questionNum={7}
+                totalQuestions={11}
+              />
+              <ScoreBody
+                totalScore={86}
+                accuracy={80}
+                completeness={60}
+                fluency={85}
+                prosody={70}
+              />
+            </ResultArea>
           </PartArea>
           <PartArea>
-            <p>Part4</p>
-            <QuestionBox>
-              <QuestionTitle>Question 8 of 11</QuestionTitle>
-              <QuestionText>
-                Welcome to the Boston International Airport. Your check-in
-                process will take ten to fifteen minutes. In order to speed up
-                the process, please have your identification and boardingpass
-                ready as you approach the counter. Also, please make sure your
-                luggage is labeled with your name, address and telephone number.
-              </QuestionText>
-            </QuestionBox>
-            <QuestionBox>
-              <QuestionTitle>Question 9 of 11</QuestionTitle>
-              <QuestionText>
-                Welcome to the Boston International Airport. Your check-in
-                process will take ten to fifteen minutes. In order to speed up
-                the process, please have your identification and boardingpass
-                ready as you approach the counter. Also, please make sure your
-                luggage is labeled with your name, address and telephone number.
-              </QuestionText>
-            </QuestionBox>
-            <QuestionBox>
-              <QuestionTitle>Question 10 of 11</QuestionTitle>
-              <QuestionText>
-                Welcome to the Boston International Airport. Your check-in
-                process will take ten to fifteen minutes. In order to speed up
-                the process, please have your identification and boardingpass
-                ready as you approach the counter. Also, please make sure your
-                luggage is labeled with your name, address and telephone number.
-              </QuestionText>
-            </QuestionBox>
+            <p className="partInfo">Part4</p>
+            <ResultArea>
+              <PassageBody
+                text={textContent}
+                isScoring={true}
+                questionNum={8}
+                totalQuestions={11}
+              />
+              <ScoreBody
+                totalScore={86}
+                accuracy={80}
+                completeness={60}
+                fluency={85}
+                prosody={70}
+              />
+            </ResultArea>
+            <ResultArea>
+              <PassageBody
+                text={textContent}
+                isScoring={true}
+                questionNum={9}
+                totalQuestions={11}
+              />
+              <ScoreBody
+                totalScore={86}
+                accuracy={80}
+                completeness={60}
+                fluency={85}
+                prosody={70}
+              />
+            </ResultArea>
+            <ResultArea>
+              <PassageBody
+                text={textContent}
+                isScoring={true}
+                questionNum={10}
+                totalQuestions={11}
+              />
+              <ScoreBody
+                totalScore={86}
+                accuracy={80}
+                completeness={60}
+                fluency={85}
+                prosody={70}
+              />
+            </ResultArea>
           </PartArea>
           <PartArea>
-            <p>Part5</p>
-            <QuestionBox>
-              <QuestionTitle>Question 11 of 11</QuestionTitle>
-              <QuestionText>
-                Welcome to the Boston International Airport. Your check-in
-                process will take ten to fifteen minutes. In order to speed up
-                the process, please have your identification and boardingpass
-                ready as you approach the counter. Also, please make sure your
-                luggage is labeled with your name, address and telephone number.
-              </QuestionText>
-            </QuestionBox>
+            <p className="partInfo">Part5</p>
+            <ResultArea>
+              <PassageBody
+                text={textContent}
+                isScoring={true}
+                questionNum={11}
+                totalQuestions={11}
+              />
+              <ScoreBody
+                totalScore={86}
+                accuracy={80}
+                completeness={60}
+                fluency={85}
+                prosody={70}
+              />
+            </ResultArea>
           </PartArea>
         </ModalContent>
       </ModalContainer>

--- a/src/components/PassageBody.tsx
+++ b/src/components/PassageBody.tsx
@@ -1,4 +1,4 @@
-// ContentBody.tsx
+// PassageBody.tsx
 import styled from "styled-components";
 
 // 특정 단어를 하이라이트하는 함수
@@ -127,14 +127,13 @@ export const OrangeHighlight = styled.span`
 const Wrapper = styled.div`
   width: 87.5rem;
   height: 25rem;
-  margin-top: 9.625rem;
+  /* margin-top: 9.625rem; */
   background-color: #ffffff;
   border-radius: 1rem;
   filter: drop-shadow(0px 4px 8px rgba(0, 0, 0, 0.25));
 
   display: flex;
   flex-direction: column;
-  /* justify-content: center; */
   align-items: center;
 
   p.question {
@@ -153,19 +152,29 @@ const Wrapper = styled.div`
     font-size: 2rem;
     font-weight: 400;
     line-height: 3rem; // 48px
+    text-align: left;
     /* display: inline-block; */
   }
 `;
 
-type ContentBodyProps = {
+type PassageBodyProps = {
   text: string;
   isScoring: boolean;
+  questionNum: number;
+  totalQuestions: number;
 };
 
-const ContentBody: React.FC<ContentBodyProps> = ({ text, isScoring }) => {
+const PassageBody: React.FC<PassageBodyProps> = ({
+  text,
+  isScoring,
+  questionNum,
+  totalQuestions,
+}) => {
   return (
     <Wrapper>
-      <p className="question">Question 1 of 2</p>
+      <p className="question">
+        Question {questionNum} of {totalQuestions}
+      </p>
       <div>
         <p className="paragraph">{highlightText(text, isScoring)}</p>
       </div>
@@ -173,4 +182,4 @@ const ContentBody: React.FC<ContentBodyProps> = ({ text, isScoring }) => {
   );
 };
 
-export default ContentBody;
+export default PassageBody;

--- a/src/components/ScoreBody.styled.ts
+++ b/src/components/ScoreBody.styled.ts
@@ -10,6 +10,7 @@ export const ScoreContainer = styled.div`
   filter: drop-shadow(0px 4px 8px rgba(0, 0, 0, 0.25));
 
   p {
+    text-align: left;
     margin: 0;
     font-size: 1.5rem;
     font-weight: bold;
@@ -90,6 +91,8 @@ export const GridBody = styled.div`
 
 // 점수 줄 (각 항목)
 export const ScoreRow = styled.div`
+  position: relative;
+
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -188,6 +191,8 @@ export const ScoreBarContainer = styled.div`
 
 // 바 차트 (점수값에 따라 길이 조정)
 export const ScoreBar = styled.div<{ width: number; color: string }>`
+  position: relative;
+
   width: ${(props) => props.width}%;
   height: 100%;
   background: ${(props) => props.color};
@@ -197,6 +202,7 @@ export const ScoreBar = styled.div<{ width: number; color: string }>`
 
 export const ScoreValue = styled.div<{ width: number; color: string }>`
   padding-left: ${({ width }) => width / 4 - 0.5}rem;
+  text-align: left;
   font-size: 1rem;
   font-weight: bold;
   color: ${(props) => props.color};

--- a/src/components/ScoreBody.tsx
+++ b/src/components/ScoreBody.tsx
@@ -56,13 +56,6 @@ const ScoreBody: React.FC<ScoreProps> = ({
 
   return (
     <ScoreContainer>
-      {/* ✅ InfoTip */}
-      {/* <InfoTip
-        content={tooltipContent}
-        visible={tooltipVisible}
-        position={tooltipPosition}
-      /> */}
-
       <TotalScoreArea>
         <div style={{ margin: "1.5rem 1.875rem" }}>
           <p>발음 점수</p>

--- a/src/pages/TestPage.tsx
+++ b/src/pages/TestPage.tsx
@@ -2,7 +2,7 @@
 import React, { useEffect, useState } from "react";
 import * as S from "./Main.styled";
 import ScoreBody from "../components/ScoreBody";
-import ContentBody, { highlightText } from "../components/ContentBody";
+import PassageBody from "../components/PassageBody";
 
 import styled from "styled-components";
 
@@ -33,6 +33,10 @@ export const TimeInfoText = styled.p`
   font-size: 1.5rem;
 `;
 
+export const TopBlank = styled.div`
+  height: 9rem;
+`;
+
 const TestPage: React.FC = () => {
   const [isPreparing, setPreparing] = useState(true);
   const [isResponding, setResponding] = useState(false);
@@ -58,23 +62,29 @@ const TestPage: React.FC = () => {
   }, [remainingTime, isPreparing, isResponding]);
 
   // 개발용 함수
-  function handleNextStep() {
-    if (isPreparing) {
-      setPreparing(false);
-      setResponding(true);
-      setRemainingTime(5);
-    } else if (isResponding) {
-      setResponding(false);
-      setScoring(true);
-    }
-  }
+  // function handleNextStep() {
+  //   if (isPreparing) {
+  //     setPreparing(false);
+  //     setResponding(true);
+  //     setRemainingTime(5);
+  //   } else if (isResponding) {
+  //     setResponding(false);
+  //     setScoring(true);
+  //   }
+  // }
 
   const textContent =
     "Welcome to the Boston International Airport. Your check-in process will take ten to fifteen minutes. In order to speed up the process, please have your identification and boardingpass ready as you approach the counter. Also, please make sure your luggage is labeled with your name, address and telephone number.";
 
   return (
     <S.mainContainer>
-      <ContentBody text={textContent} isScoring={isScoring} />
+      <TopBlank />
+      <PassageBody
+        text={textContent}
+        isScoring={isScoring}
+        questionNum={1}
+        totalQuestions={2}
+      />
       {isPreparing && (
         <>
           <TimeRemainingIndicator>


### PR DESCRIPTION
## 📝 변경 사항  
[//]: # (이 PR에서 수행된 변경 사항에 대해 설명)  
- 시험 결과 모달 창의 지문 Container를 테스트 페이지에서 만든 컴포넌트로 변경
- 시험 결과 모달 창 디자인 개선 (세로 길이, 가로 바 없애기 등)
- Part 안내 블록이 스크롤 됨에 따라 따라오며 Part 가 변하면 덮어씌우게 구현
- 일부 컴포넌트 이름 수정
  
## 🔍 관련 이슈  
- 이 PR이 해결하는 이슈: #16 
  
## ✅ 테스트 결과  
- [ ] 기능 테스트 완료  
  
## 📌 추가 사항  
- <추가로 고려해야 할 사항>