### PR TITLE
feat: 모의고사 취소 API 연동

### DIFF
--- a/src/hooks/useMockTestCancel.ts
+++ b/src/hooks/useMockTestCancel.ts
@@ -1,0 +1,57 @@
+import { useEffect } from "react";
+import axios from "axios";
+import { useMockTestStore } from "../stores/MockTestStore";
+
+export const useMockTestCancel = (
+  isMockExam: boolean,
+  sessionId: string | null,
+) => {
+  const resetMockTest = useMockTestStore((state) => state.resetMockTest);
+
+  useEffect(() => {
+    if (!isMockExam || !sessionId) return;
+
+    const cancelWithSendBeacon = () => {
+      console.log("모의고사 취소 요청");
+      const url = `/api/mocktest/${sessionId}/cancel`;
+      const blob = new Blob([], { type: "application/json" });
+      navigator.sendBeacon(url, blob);
+    };
+
+    const cancelWithAxios = async () => {
+      try {
+        await axios.post(`/api/mocktest/${sessionId}/cancel`);
+        console.log("모의고사 세션 취소 성공");
+      } catch (error) {
+        console.error("모의고사 세션 취소 실패:", error);
+      }
+    };
+
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      console.log("새로고침 또는 닫힘 감지");
+      cancelWithSendBeacon();
+      event.preventDefault();
+    };
+
+    const handlePopState = async () => {
+      console.log("뒤로가기 감지");
+      await cancelWithAxios();
+      resetMockTest();
+
+      alert(
+        "모의고사가 비정상적으로 종료되었습니다. 메인 화면으로 이동합니다.",
+      );
+      setTimeout(() => {
+        window.location.href = "/";
+      }, 100);
+    };
+
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    window.addEventListener("popstate", handlePopState);
+
+    return () => {
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+      window.removeEventListener("popstate", handlePopState);
+    };
+  }, [isMockExam, sessionId, resetMockTest]);
+};

--- a/src/pages/Part1Page.tsx
+++ b/src/pages/Part1Page.tsx
@@ -11,6 +11,7 @@ import { encodeWAV } from "./encodeWAV";
 
 import StopTalkingModal from "../components/StopTalkingModal";
 import { useMockTestStore } from "../stores/MockTestStore";
+import { useMockTestCancel } from "../hooks/useMockTestCancel";
 
 const IS_DEV_MODE = true;
 //const IS_DEV_MODE = false;
@@ -60,6 +61,7 @@ const Part1Page: React.FC = () => {
   const isMockExam = searchParams.get("mockExam") === "true"; // URL에서 mockExam 값 확인
   const { partQuestions, sessionId } = useMockTestStore();
   const [isUploadComplete, setIsUploadComplete] = useState(false);
+  useMockTestCancel(isMockExam, sessionId);
 
   const location = useLocation();
   const fromPartSelect = location.state?.fromPartSelect;
@@ -94,6 +96,16 @@ const Part1Page: React.FC = () => {
   //useRef로 동기적 관리
   const questionPart1IdRef = useRef<number>(initialQuestions?.questionPart1Id);
   const currentNumRef = useRef(1);
+
+  // 새로고침 후 sessionId 초기화된 경우 메인으로 리디렉션
+  useEffect(() => {
+    if (isMockExam && !sessionId) {
+      setTimeout(() => {
+        alert("세션이 유효하지 않아 메인으로 이동합니다.");
+        window.location.href = "/";
+      }, 100); // 100ms 지연
+    }
+  }, [isMockExam, sessionId]);
 
   function increaseNum() {
     setCurrentNum((prevNum) => {

--- a/src/pages/Part2Page.tsx
+++ b/src/pages/Part2Page.tsx
@@ -12,6 +12,7 @@ import { encodeWAV } from "./encodeWAV";
 
 import StopTalkingModal from "../components/StopTalkingModal";
 import { useMockTestStore } from "../stores/MockTestStore";
+import { useMockTestCancel } from "../hooks/useMockTestCancel";
 
 const IS_DEV_MODE = true;
 //const IS_DEV_MODE = false;
@@ -62,6 +63,7 @@ const Part2Page: React.FC = () => {
   const isMockExam = searchParams.get("mockExam") === "true"; // URL에서 mockExam 값 확인
   const { partQuestions, sessionId } = useMockTestStore();
   const [isUploadComplete, setIsUploadComplete] = useState(false);
+  useMockTestCancel(isMockExam, sessionId);
 
   const location = useLocation();
   const fromPartSelect = location.state?.fromPartSelect;
@@ -97,6 +99,15 @@ const Part2Page: React.FC = () => {
   const questionPart2IdRef = useRef<number>(initialQuestions?.questionPart2Id);
   const currentNumRef = useRef(3);
 
+  // 새로고침 후 sessionId 초기화된 경우 메인으로 리디렉션
+  useEffect(() => {
+    if (isMockExam && !sessionId) {
+      setTimeout(() => {
+        alert("세션이 유효하지 않아 메인으로 이동합니다.");
+        window.location.href = "/";
+      }, 100); // 100ms 지연
+    }
+  }, [isMockExam, sessionId]);
   function increaseNum() {
     setCurrentNum((prevNum) => {
       const newNum = prevNum + 1;

--- a/src/pages/Part3Page.tsx
+++ b/src/pages/Part3Page.tsx
@@ -14,6 +14,7 @@ import { encodeWAV } from "./encodeWAV";
 
 import StopTalkingModal from "../components/StopTalkingModal";
 import { useMockTestStore } from "../stores/MockTestStore";
+import { useMockTestCancel } from "../hooks/useMockTestCancel";
 
 // 개발 모드인지 여부를 플래그 변수로 설정
 // true : 개발 모드 (빠른 UI 확인용)
@@ -64,6 +65,7 @@ const Part3Page: React.FC = () => {
   const isMockExam = searchParams.get("mockExam") === "true"; // URL에서 mockExam 값 확인
   const { partQuestions, sessionId } = useMockTestStore();
   const [isUploadComplete, setIsUploadComplete] = useState(false);
+  useMockTestCancel(isMockExam, sessionId);
 
   const location = useLocation();
   const fromPartSelect = location.state?.fromPartSelect;
@@ -121,6 +123,16 @@ const Part3Page: React.FC = () => {
   //useRef로 동기적 관리
   const questionPart3IdRef = useRef<number>(initialQuestions?.questionPart3Id);
   const currentNumRef = useRef(5);
+
+  // 새로고침 후 sessionId 초기화된 경우 메인으로 리디렉션
+  useEffect(() => {
+    if (isMockExam && !sessionId) {
+      setTimeout(() => {
+        alert("세션이 유효하지 않아 메인으로 이동합니다.");
+        window.location.href = "/";
+      }, 100); // 100ms 지연
+    }
+  }, [isMockExam, sessionId]);
 
   function increaseNum() {
     // setCurrentNum((prevNum) => prevNum + 1);

--- a/src/pages/Part4Page.tsx
+++ b/src/pages/Part4Page.tsx
@@ -14,6 +14,7 @@ import loadingGif from "../assets/img/loading.gif";
 
 import { encodeWAV } from "./encodeWAV";
 import { useMockTestStore } from "../stores/MockTestStore";
+import { useMockTestCancel } from "../hooks/useMockTestCancel";
 
 // 개발 모드인지 여부를 플래그 변수로 설정
 // true : 개발 모드 (빠른 UI 확인용)
@@ -64,6 +65,7 @@ const Part4Page: React.FC = () => {
   const isMockExam = searchParams.get("mockExam") === "true";
   const { partQuestions, sessionId } = useMockTestStore();
   const [isUploadComplete, setIsUploadComplete] = useState(false);
+  useMockTestCancel(isMockExam, sessionId);
 
   const location = useLocation();
   const fromPartSelect = location.state?.fromPartSelect;
@@ -121,6 +123,16 @@ const Part4Page: React.FC = () => {
   //useRef로 동기적 관리
   const questionPart4IdRef = useRef<number>(initialQuestions?.questionPart4Id);
   const currentNumRef = useRef<number>(currentNum); // ← currentNum(8)과 동기화
+
+  // 새로고침 후 sessionId 초기화된 경우 메인으로 리디렉션
+  useEffect(() => {
+    if (isMockExam && !sessionId) {
+      setTimeout(() => {
+        alert("세션이 유효하지 않아 메인으로 이동합니다.");
+        window.location.href = "/";
+      }, 100); // 100ms 지연
+    }
+  }, [isMockExam, sessionId]);
 
   function increaseNum() {
     setCurrentNum((prev) => {

--- a/src/pages/Part5Page.tsx
+++ b/src/pages/Part5Page.tsx
@@ -11,6 +11,7 @@ import { encodeWAV } from "./encodeWAV";
 
 import StopTalkingModal from "../components/StopTalkingModal";
 import { useMockTestStore } from "../stores/MockTestStore";
+import { useMockTestCancel } from "../hooks/useMockTestCancel";
 
 const IS_DEV_MODE = true;
 //const IS_DEV_MODE = false;
@@ -59,6 +60,7 @@ const Part5Page: React.FC = () => {
   const isMockExam = searchParams.get("mockExam") === "true"; // URL에서 mockExam 값 확인
   const { partQuestions, sessionId } = useMockTestStore();
   const [isUploadComplete, setIsUploadComplete] = useState(false);
+  useMockTestCancel(isMockExam, sessionId);
 
   const location = useLocation();
   const fromPartSelect = location.state?.fromPartSelect;
@@ -93,6 +95,16 @@ const Part5Page: React.FC = () => {
   //useRef로 동기적 관리
   const questionPart5IdRef = useRef<number>(initialQuestions?.questionPart5Id);
   const currentNum = 11;
+
+  // 새로고침 후 sessionId 초기화된 경우 메인으로 리디렉션
+  useEffect(() => {
+    if (isMockExam && !sessionId) {
+      setTimeout(() => {
+        alert("세션이 유효하지 않아 메인으로 이동합니다.");
+        window.location.href = "/";
+      }, 100); // 100ms 지연
+    }
+  }, [isMockExam, sessionId]);
 
   useEffect(() => {
     if (isMockExam) {


### PR DESCRIPTION
## 📝 변경 사항  
[//]: # (이 PR에서 수행된 변경 사항에 대해 설명)  
- 모의고사 취소를 custom hook으로 구현
- useEffect로 Part별 페이지에서 sessionId가 없을 경우 메인으로 리디렉션 하도록 구현
  
## 🔍 관련 이슈  
- 이 PR이 해결하는 이슈: #135
  
## ✅ 테스트 결과  
- [x] 기능 테스트 완료  
- [x] 버그 테스트 완료  
  
## 📌 추가 사항  
- <추가로 고려해야 할 사항>