### PR TITLE
design: 모의고사 결과용 페이지 퍼블리싱 및 모의고사 결과 응답 파싱

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import TestResultPage from "./pages/TestResult";
 import TempPart1Page from "./pages/TempPart1Page";
 import TempPart5Page from "./pages/TempPart5Page";
 import MockDirectionPage from "./pages/MockDirectionPage";
+import MockExamResultPage from "./pages/MockExamResultPage";
 
 const App: React.FC = () => {
   return (
@@ -147,6 +148,14 @@ const App: React.FC = () => {
           element={
             <MainLayout>
               <MockDirectionPage />
+            </MainLayout>
+          }
+        />
+        <Route
+          path="/mockresult"
+          element={
+            <MainLayout>
+              <MockExamResultPage />
             </MainLayout>
           }
         />

--- a/src/components/QuestionBody.tsx
+++ b/src/components/QuestionBody.tsx
@@ -2,7 +2,7 @@ import styled from "styled-components";
 
 const Wrapper = styled.div`
   width: 87.5rem;
-  height: 25rem;
+  min-height: 15rem;
   /* margin-top: 9.625rem; */
   background-color: #ffffff;
   border-radius: 1rem;

--- a/src/components/ReplyBody.tsx
+++ b/src/components/ReplyBody.tsx
@@ -89,7 +89,7 @@ export const Highlight = styled.span<{ score: number }>`
 
 const Wrapper = styled.div`
   width: 87.5rem;
-  min-height: 36rem;
+  min-height: 24rem;
   margin: 3rem 0 -1.5rem 0;
   background-color: #ffffff;
   border-radius: 1rem;

--- a/src/components/SituationBody.tsx
+++ b/src/components/SituationBody.tsx
@@ -75,7 +75,7 @@ const Part4Question = styled.div<WrapperProps>`
     margin-bottom: 0.5rem;
     align-self: flex-start;
   }
-`
+`;
 
 type SituationBodyProps = {
   stage: string;
@@ -131,14 +131,14 @@ const SituationBody: React.FC<SituationBodyProps> = ({
               <img src={imageSrc} alt="Question Image" />
               <p className="content">{situationText}</p>
             </>
-        ) : (
-          <>
-            <img src={imageSrc} alt="Question Image" />
-            <p className="content">{situationText}</p>
-            <p className="question">Question {questionNum}.</p>
-            <p className="content">{questionText}</p>
-          </>
-        )}
+          ) : (
+            <>
+              <img src={imageSrc} alt="Question Image" />
+              <p className="content">{situationText}</p>
+              <p className="question">Question {questionNum}.</p>
+              <p className="content">{questionText}</p>
+            </>
+          )}
         </Part4Question>
       )}
     </Wrapper>

--- a/src/components/StudyStatChart.tsx
+++ b/src/components/StudyStatChart.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Bar } from "react-chartjs-2";
+import { ChartOptions } from "chart.js";
 import {
   Chart as ChartJS,
   CategoryScale,
@@ -19,62 +20,65 @@ ChartJS.register(
   Legend,
 );
 
-const data = {
-  labels: ["Part1", "Part2", "Part3", "Part4", "Part5"],
-  datasets: [
-    {
-      label: "학습 통계",
-      data: [80, 50, 30, 70, 85],
-      // backgroundColor: "rgba(255, 99, 132, 0.8)",
-      backgroundColor: "#FF5151",
-      borderRadius: 50,
-      borderSkipped: false,
-      barThickness: 30,
-    },
-  ],
-};
+interface StudyStatChartProps {
+  scores: number[];
+}
 
-const options = {
-  responsive: true,
-  scales: {
-    x: {
-      grid: {
-        display: true, // X축 그리드 활성화
-        drawTicks: true, // 눈금만 표시
-        drawOnChartArea: true, // 그래프 내부 선 제거
+const StudyStatChart: React.FC<StudyStatChartProps> = ({ scores }) => {
+  const data = {
+    labels: ["Part1", "Part2", "Part3", "Part4", "Part5"],
+    datasets: [
+      {
+        label: "학습 통계",
+        data: scores,
+        backgroundColor: "#FF5151",
+        borderRadius: 50,
+        borderSkipped: false,
+        barThickness: 30,
       },
-      ticks: {
-        font: {
-          size: 16, // ✅ X축 글자 크기 증가
+    ],
+  };
+
+  const options: ChartOptions<"bar"> = {
+    responsive: true,
+    scales: {
+      x: {
+        grid: {
+          display: true,
+          drawTicks: true,
+          drawOnChartArea: true,
         },
-        padding: 16,
-      },
-    },
-    y: {
-      grid: {
-        display: true, // Y축 내부 눈금 제거
-        color: "transparent", // ✅ 일반 Y축 선을 안 보이게 설정
-      },
-
-      beginAtZero: true,
-      max: 100,
-      position: "right", // Y축을 오른쪽에 배치
-      ticks: {
-        stepSize: 25, // ✅ Y축 눈금을 25 단위로 표시
-        font: {
-          size: 16, // ✅ Y축 글자 크기 증가
+        ticks: {
+          font: {
+            size: 16,
+          },
+          padding: 16,
         },
       },
+      y: {
+        type: "linear",
+        position: "right",
+        beginAtZero: true,
+        max: 100,
+        grid: {
+          display: true,
+          color: "transparent",
+        },
+        ticks: {
+          stepSize: 25,
+          font: {
+            size: 16,
+          },
+        },
+      },
     },
-  },
-  plugins: {
-    legend: {
-      display: false, // 범례 숨기기
+    plugins: {
+      legend: {
+        display: false,
+      },
     },
-  },
-};
+  };
 
-const StudyStatChart = () => {
   return <Bar data={data} options={options} />;
 };
 

--- a/src/pages/MockExamResult.styled.ts
+++ b/src/pages/MockExamResult.styled.ts
@@ -1,0 +1,150 @@
+import styled from "styled-components";
+
+export const MainContainer = styled.div`
+  width: 100%;
+  padding-top: 6.25rem;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background: white;
+`;
+
+export const TitleContainer = styled.div`
+  width: 100%;
+  height: 6rem;
+  display: flex;
+  flex-direction: row;
+  text-align: start;
+  align-items: center;
+  justify-content: start;
+  padding-left: 3.5rem;
+
+  background: #ff5151;
+  color: #fff;
+  text-align: center;
+  font-family: "Roboto";
+  font-size: 2rem;
+  font-weight: 700;
+`;
+
+export const SubTitleContainer = styled.div`
+  width: 100%;
+  height: 5rem;
+  display: flex;
+  text-align: start;
+  align-items: center;
+  justify-content: start;
+  padding-left: 3.5rem;
+
+  color: black;
+  font-family: "Roboto";
+  font-size: 1.5rem;
+  font-weight: 700;
+`;
+
+export const GradeContainer = styled.div`
+  width: 100%;
+  height: 21rem;
+  background: #f8f8f8;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+`;
+
+export const GradeArea = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 20rem;
+  justify-content: center;
+  align-items: center;
+  border-right: solid #8a8a8a 1px;
+`;
+
+export const GradeTitle = styled.div`
+  color: #000;
+  text-align: center;
+  font-family: "Noto Sans HK";
+  font-size: 1.5rem;
+  font-style: normal;
+  font-weight: 700;
+`;
+
+export const Grade = styled.div`
+  color: #000;
+
+  text-align: center;
+  font-family: "Noto Sans HK";
+  font-size: 4rem;
+  font-style: normal;
+  font-weight: 700;
+`;
+
+export const ChartArea = styled.div`
+  display: flex;
+  height: 19rem;
+  margin-right: 10rem;
+  padding: 1rem;
+`;
+
+export const PartArea = styled.div`
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  margin-bottom: 5rem;
+`;
+
+export const Part2Area = styled.div`
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  margin: 2rem 0 5rem 0;
+`;
+
+export const Part3Area = styled.div`
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  margin: 4rem 0 5rem 0;
+`;
+
+export const Part4Area = styled.div`
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  margin: 4rem 0 5rem 0;
+`;
+
+export const FloatingButton = styled.button`
+  position: fixed;
+  width: 6.25rem;
+  height: 6.25rem;
+  bottom: 5rem;
+  right: 5rem;
+  background: #ff7373;
+  border-radius: 4rem;
+  box-shadow: 0px 0px 8px 4px rgba(0, 0, 0, 0.25);
+  border: none;
+  color: #fff;
+
+  text-align: center;
+  font-family: "Inter";
+  font-size: 1.5rem;
+  font-weight: 700;
+
+  cursor: pointer;
+  z-index: 100;
+  transition: background-color 0.2s;
+
+  &:hover {
+    background: #ff5151;
+  }
+`;

--- a/src/pages/MockExamResultPage.tsx
+++ b/src/pages/MockExamResultPage.tsx
@@ -1,0 +1,344 @@
+import React from "react";
+import ScoreBody from "../components/ScoreBody";
+import ScoreBodyGeneral from "../components/ScoreBodyGeneral";
+import ReplyBody from "../components/ReplyBody";
+import MultipleReplyBody from "../components/MultipleReplyBox";
+import { useLocation, useNavigate } from "react-router-dom";
+import { useMockTestStore } from "../stores/MockTestStore";
+import PassageBody from "../components/PassageBody";
+import ImageBody from "../components/ImageBody";
+import SituationBody from "../components/SituationBody";
+import StudyStatChart from "../components/StudyStatChart";
+import {
+  ChartArea,
+  FloatingButton,
+  Grade,
+  GradeArea,
+  GradeContainer,
+  GradeTitle,
+  MainContainer,
+  Part2Area,
+  Part3Area,
+  Part4Area,
+  PartArea,
+  SubTitleContainer,
+  TitleContainer,
+} from "./MockExamResult.styled";
+import QuestionBody from "../components/QuestionBody";
+
+const MockExamResultPage: React.FC = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { assessmentJsons, grade } = location.state || {};
+  const parsed = assessmentJsons.map((json: string) => JSON.parse(json));
+  const { partQuestions } = useMockTestStore();
+
+  const getPronScores = (
+    assess: any,
+  ): {
+    accuracy: number;
+    fluency: number;
+    prosody: number;
+    completeness?: number;
+    pronunciationScore: number;
+  } => ({
+    accuracy: Math.round(assess.AccuracyScore),
+    fluency: Math.round(assess.FluencyScore),
+    prosody: Math.round(assess.ProsodyScore),
+    completeness: assess.CompletenessScore
+      ? Math.round(assess.CompletenessScore)
+      : undefined,
+    pronunciationScore: Math.round(
+      [assess.AccuracyScore, assess.FluencyScore, assess.ProsodyScore].reduce(
+        (sum: number, score: number, _: number, arr: number[]) =>
+          sum + (score === Math.min(...arr) ? score * 0.4 : score * 0.2),
+        0,
+      ),
+    ),
+  });
+
+  const getContentScores = (
+    gptEval: any,
+  ): {
+    voca: number;
+    grammar: number;
+    topic: number;
+    contentScore: number;
+    feedback: string;
+  } => ({
+    voca: Math.round(gptEval.vocabulary),
+    grammar: Math.round(gptEval.grammar),
+    topic: Math.round(gptEval.topic),
+    contentScore: Math.round(
+      (gptEval.vocabulary + gptEval.grammar + gptEval.topic) / 3,
+    ),
+    feedback: [
+      gptEval.suggestions.grammar,
+      gptEval.suggestions.vocabulary,
+      gptEval.suggestions.topic,
+      gptEval.suggestions.eval || gptEval.suggestions["총평"],
+    ].join("\n\n"),
+  });
+
+  //GPT 응답내용
+  const renderGeneralScore = (
+    data: any,
+    questionNum: number,
+    questionText: string,
+  ): JSX.Element => {
+    const pron = getPronScores(data.azureEvaluation.PronunciationAssessment);
+    const content = getContentScores(data.gptEvaluation);
+    const wrongWordScore = (data.azureEvaluation.IssueWords || []).reduce(
+      (
+        acc: Record<string, { score: number; errorType: string }>,
+        word: any,
+      ) => {
+        if (["Mispronunciation", "Omission", "None"].includes(word.ErrorType)) {
+          acc[word.word.toLowerCase()] = {
+            score: word.AccuracyScore,
+            errorType: word.ErrorType,
+          };
+        }
+        return acc;
+      },
+      {},
+    );
+
+    return (
+      <React.Fragment key={questionNum}>
+        <MultipleReplyBody
+          questionNum={questionNum}
+          questionText={questionText}
+          contentText={data.azureEvaluation.UserResponse}
+          isScoring
+          wrongWordScore={wrongWordScore}
+          feedback={content.feedback}
+        />
+        <ScoreBodyGeneral {...pron} {...content} />
+      </React.Fragment>
+    );
+  };
+
+  return (
+    <MainContainer>
+      <TitleContainer>모의고사 결과</TitleContainer>
+      <SubTitleContainer>모의고사 성적</SubTitleContainer>
+      <GradeContainer>
+        <GradeArea>
+          <GradeTitle>성적</GradeTitle>
+          <Grade>{grade.finalGrade}</Grade>
+        </GradeArea>
+        <ChartArea>
+          <StudyStatChart
+            scores={[
+              Math.round(grade.part1Score),
+              Math.round(grade.part2Score),
+              Math.round(grade.part3Score),
+              Math.round(grade.part4Score),
+              Math.round(grade.part5Score),
+            ]}
+          />
+        </ChartArea>
+        <div></div>
+      </GradeContainer>
+      <SubTitleContainer>Part 1</SubTitleContainer>
+      {[0, 1].map((i) => {
+        const assess = parsed[i];
+        const pron = getPronScores(assess.PronunciationAssessment);
+        const wrongWordScore = (assess.IssueWords || []).reduce(
+          (
+            acc: Record<string, { score: number; errorType: string }>,
+            word: any,
+          ) => {
+            if (
+              ["Mispronunciation", "Omission", "None"].includes(word.ErrorType)
+            ) {
+              acc[word.word.toLowerCase()] = {
+                score: word.AccuracyScore,
+                errorType: word.ErrorType,
+              };
+            }
+            return acc;
+          },
+          {},
+        );
+        return (
+          <PartArea key={i}>
+            <PassageBody
+              text={partQuestions.part1.questions[i]}
+              isScoring={true}
+              wrongWordScore={wrongWordScore}
+              questionNum={i + 1}
+              totalQuestions={11}
+              questionCount={i + 1}
+              partId={"1"}
+            />
+            <ScoreBody
+              totalScore={pron.pronunciationScore}
+              accuracy={pron.accuracy}
+              completeness={pron.completeness ?? 0}
+              fluency={pron.fluency}
+              prosody={pron.prosody}
+            />
+          </PartArea>
+        );
+      })}
+
+      <SubTitleContainer>Part 2</SubTitleContainer>
+      {[2, 3].map((i) => {
+        const data = parsed[i];
+        const pron = getPronScores(
+          data.azureEvaluation.PronunciationAssessment,
+        );
+        const content = getContentScores(data.gptEvaluation);
+        const wrongWordScore = (data.azureEvaluation.IssueWords || []).reduce(
+          (
+            acc: Record<string, { score: number; errorType: string }>,
+            word: any,
+          ) => {
+            if (
+              ["Mispronunciation", "Omission", "None"].includes(word.ErrorType)
+            ) {
+              acc[word.word.toLowerCase()] = {
+                score: word.AccuracyScore,
+                errorType: word.ErrorType,
+              };
+            }
+            return acc;
+          },
+          {},
+        );
+
+        return (
+          <Part2Area key={i}>
+            <ImageBody
+              imageSrc={partQuestions.part2.questions[i - 2]}
+              questionNum={i + 1}
+              totalQuestions={11}
+              questionCount={i - 1}
+              partId={"2"}
+            />
+            <ReplyBody
+              text={data.azureEvaluation.UserResponse}
+              wrongWordScore={wrongWordScore}
+              isScoring={true}
+              gptText={content.feedback}
+            />
+            <ScoreBodyGeneral {...pron} {...content} />
+          </Part2Area>
+        );
+      })}
+
+      <SubTitleContainer>Part 3</SubTitleContainer>
+      <Part3Area>
+        <SituationBody
+          stage="scoring"
+          partNum={3}
+          situationText={partQuestions.part3.situationText ?? undefined}
+          questionText={""}
+          questionNum={5}
+          totalQuestions={11}
+          questionCount={1}
+          partId={"3"}
+        />
+        {[4, 5, 6].map((i, idx) =>
+          renderGeneralScore(
+            parsed[i],
+            5 + idx,
+            partQuestions.part3.questions[idx],
+          ),
+        )}
+      </Part3Area>
+
+      <SubTitleContainer>Part 4</SubTitleContainer>
+      <Part4Area>
+        <SituationBody
+          stage="scoring"
+          partNum={4}
+          situationText={partQuestions.part4.situationText ?? undefined}
+          imageSrc={partQuestions.part4.situationImage ?? undefined}
+          questionText={""}
+          questionNum={8}
+          totalQuestions={11}
+          questionCount={1}
+          partId={"4"}
+        />
+        {[7, 8, 9].map((i, idx) =>
+          renderGeneralScore(
+            parsed[i],
+            8 + idx,
+            partQuestions.part4.questions[idx],
+          ),
+        )}
+      </Part4Area>
+
+      <SubTitleContainer>Part 5</SubTitleContainer>
+      <PartArea>
+        <QuestionBody
+          text={partQuestions.part5.questions[0]}
+          questionNum={11}
+          totalQuestions={11}
+          questionCount={1}
+          fromPartSelect={false}
+          partId={"5"}
+        />
+        {(() => {
+          const data = parsed[10]; // 마지막 문제
+          const pron = getPronScores(
+            data.azureEvaluation.PronunciationAssessment,
+          );
+          const content = getContentScores(data.gptEvaluation);
+          const wrongWordScore = (data.azureEvaluation.IssueWords || []).reduce(
+            (
+              acc: Record<string, { score: number; errorType: string }>,
+              word: any,
+            ) => {
+              if (
+                ["Mispronunciation", "Omission", "None"].includes(
+                  word.ErrorType,
+                )
+              ) {
+                acc[word.word.toLowerCase()] = {
+                  score: word.AccuracyScore,
+                  errorType: word.ErrorType,
+                };
+              }
+              return acc;
+            },
+            {},
+          );
+
+          return (
+            <>
+              <ReplyBody
+                text={data.azureEvaluation.UserResponse}
+                wrongWordScore={wrongWordScore}
+                isScoring
+                gptText={content.feedback}
+              />
+              <ScoreBodyGeneral {...pron} {...content} />
+            </>
+          );
+        })()}
+      </PartArea>
+      <FloatingButton onClick={() => navigate("/")}>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="60"
+          height="60"
+          viewBox="0 0 60 60"
+          fill="none"
+        >
+          <path
+            fill-rule="evenodd"
+            clip-rule="evenodd"
+            d="M28.2325 8.23197C28.7014 7.76329 29.3371 7.5 30 7.5C30.663 7.5 31.2987 7.76329 31.7675 8.23197L46.7675 23.232L51.7675 28.232C52.2229 28.7035 52.4749 29.335 52.4692 29.9905C52.4635 30.646 52.2006 31.273 51.7371 31.7365C51.2736 32.2 50.6465 32.463 49.991 32.4687C49.3355 32.4743 48.704 32.2224 48.2325 31.767L47.5 31.0345V47.4995C47.5 48.8255 46.9733 50.0973 46.0356 51.035C45.0979 51.9727 43.8261 52.4995 42.5 52.4995H35C34.337 52.4995 33.7011 52.2361 33.2323 51.7672C32.7634 51.2984 32.5 50.6625 32.5 49.9995V42.4995H27.5V49.9995C27.5 50.6625 27.2366 51.2984 26.7678 51.7672C26.299 52.2361 25.6631 52.4995 25 52.4995H17.5C16.174 52.4995 14.9022 51.9727 13.9645 51.035C13.0268 50.0973 12.5 48.8255 12.5 47.4995V31.0345L11.7675 31.767C11.296 32.2224 10.6645 32.4743 10.009 32.4687C9.35355 32.463 8.72652 32.2 8.26299 31.7365C7.79947 31.273 7.53655 30.646 7.53086 29.9905C7.52516 29.335 7.77715 28.7035 8.23254 28.232L13.2325 23.232L28.2325 8.23197Z"
+            fill="white"
+          />
+        </svg>
+      </FloatingButton>
+    </MainContainer>
+  );
+};
+
+export default MockExamResultPage;

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -151,7 +151,7 @@ const MyPage: React.FC = () => {
                   <ExamScore>IM1</ExamScore>
                 </ScoreaArea>
                 <ExamGraph>
-                  <StudyStatChart />
+                  <StudyStatChart scores={[80, 65, 70, 50, 90]} />
                 </ExamGraph>
               </ExamRecord>
               <ExamRecord onClick={() => openModal("2025/01/03")}>

--- a/src/pages/Part2Page.tsx
+++ b/src/pages/Part2Page.tsx
@@ -320,12 +320,6 @@ const Part2Page: React.FC = () => {
     }
   };
 
-  useEffect(() => {
-    console.log("questionPart2Id", questions?.questionPart2Id);
-    console.log("question3:", questions?.question3);
-    console.log("question4:", questions?.question4);
-  }, [questions]);
-
   const nextQuestion = async () => {
     if (questionIndex === 0) {
       // 기존 문제 세트에서 다음 문제로 이동

--- a/src/pages/Part5Page.tsx
+++ b/src/pages/Part5Page.tsx
@@ -168,7 +168,7 @@ const Part5Page: React.FC = () => {
       if (isMockExam) {
         console.log("모의고사 업로드 실행");
         const res = await axios.post(
-          `/api/mocktest/${sessionId}/save/3/${questionNo}`,
+          `/api/mocktest/${sessionId}/save/5/${questionNo}`,
           formData,
         );
 
@@ -241,13 +241,19 @@ const Part5Page: React.FC = () => {
       try {
         const res = await axios.post(`/api/mocktest/${sessionId}/complete`);
         console.log("모의고사 완료 응답:", res.data);
+        navigate("/mockresult", {
+          state: {
+            assessmentJsons: res.data.assessmentJsons,
+            grade: res.data.grade,
+          },
+        });
       } catch (err) {
         console.error("모의고사 완료 요청 실패:", err);
       }
     };
 
     completeMockTest();
-  }, [isUploadComplete, isMockExam, sessionId]);
+  }, [isUploadComplete, isMockExam, sessionId, navigate]);
 
   useEffect(() => {
     if (!audioRef.current) {


### PR DESCRIPTION
## 📝 변경 사항  
[//]: # (이 PR에서 수행된 변경 사항에 대해 설명)  
- 모의고사 결과용 페이지 퍼블리싱
- 모의고사 완료 응답 파싱해서 모의고사 결과 페이지에 적용
- 각 컴포넌트 margin 소폭 조정
- StudyStatChart props를 받도록 수정
  
## 🔍 관련 이슈  
- 이 PR이 해결하는 이슈: #137 
  
## ✅ 테스트 결과  
- [x] 기능 테스트 완료  
- [x] 버그 테스트 완료  