### PR TITLE
feat: 모의고사 결과페이지 성적 Bar UI 적용

### DIFF
--- a/src/components/QuestionBody.tsx
+++ b/src/components/QuestionBody.tsx
@@ -34,7 +34,7 @@ const Wrapper = styled.div`
 `;
 
 type QuestionBodyProps = {
-  text: string;
+  text: string | JSX.Element | JSX.Element[];
   questionNum: number;
   totalQuestions: number;
   fromPartSelect?: boolean;

--- a/src/pages/MockExamResult.styled.ts
+++ b/src/pages/MockExamResult.styled.ts
@@ -80,10 +80,16 @@ export const Grade = styled.div`
   font-weight: 700;
 `;
 
+export const ScoreArea = styled.div`
+  display: flex;
+  padding: 1rem;
+  align-items: center;
+`;
+
 export const ChartArea = styled.div`
   display: flex;
   height: 19rem;
-  margin-right: 10rem;
+  margin-right: 15rem;
   padding: 1rem;
 `;
 

--- a/src/pages/MockExamResultPage.tsx
+++ b/src/pages/MockExamResultPage.tsx
@@ -21,10 +21,12 @@ import {
   Part3Area,
   Part4Area,
   PartArea,
+  ScoreArea,
   SubTitleContainer,
   TitleContainer,
 } from "./MockExamResult.styled";
 import QuestionBody from "../components/QuestionBody";
+import { GradationBarBox } from "../components/GradationBarBox";
 
 const MockExamResultPage: React.FC = () => {
   const navigate = useNavigate();
@@ -32,6 +34,24 @@ const MockExamResultPage: React.FC = () => {
   const { assessmentJsons, grade } = location.state || {};
   const parsed = assessmentJsons.map((json: string) => JSON.parse(json));
   const { partQuestions } = useMockTestStore();
+
+  // question 본문의 '?' 이후 줄바꿈용
+  const formattedText = (partQuestions.part5.questions[0] ?? "")
+    .split("?")
+    .map((part: string, index: number, arr: string[]) => (
+      <React.Fragment key={index}>
+        {part}
+        {index < arr.length - 1 && "?"}
+        {index === 0 && <br />}
+      </React.Fragment>
+    ));
+
+  // finalGrade에서 등급(level)만 추출
+  const parseFinalGrade = (finalGrade: string): string => {
+    return finalGrade.replace(/^\d+\s*/, ""); // 숫자와 공백 제거 → 등급만 반환
+  };
+
+  const level = parseFinalGrade(grade.finalGrade);
 
   const getPronScores = (
     assess: any,
@@ -126,8 +146,11 @@ const MockExamResultPage: React.FC = () => {
       <GradeContainer>
         <GradeArea>
           <GradeTitle>성적</GradeTitle>
-          <Grade>{grade.finalGrade}</Grade>
+          <Grade>{level}</Grade>
         </GradeArea>
+        <ScoreArea>
+          <GradationBarBox testGrade={grade.finalGrade} />
+        </ScoreArea>
         <ChartArea>
           <StudyStatChart
             scores={[
@@ -139,7 +162,6 @@ const MockExamResultPage: React.FC = () => {
             ]}
           />
         </ChartArea>
-        <div></div>
       </GradeContainer>
       <SubTitleContainer>Part 1</SubTitleContainer>
       {[0, 1].map((i) => {
@@ -275,7 +297,7 @@ const MockExamResultPage: React.FC = () => {
       <SubTitleContainer>Part 5</SubTitleContainer>
       <PartArea>
         <QuestionBody
-          text={partQuestions.part5.questions[0]}
+          text={formattedText}
           questionNum={11}
           totalQuestions={11}
           questionCount={1}

--- a/src/pages/Part3Page.tsx
+++ b/src/pages/Part3Page.tsx
@@ -378,6 +378,7 @@ const Part3Page: React.FC = () => {
           setRemainingTime(TIME_SETTINGS.preparing);
           break;
         case "preparing":
+          setStage("responding");
           setRemainingTime(TIME_SETTINGS.responding(currentNum)); // 문항별 응답 시간 설정
           setIsSubmitting(false);
           break;


### PR DESCRIPTION
## 📝 변경 사항  
[//]: # (이 PR에서 수행된 변경 사항에 대해 설명)  
- 기존 모의고사 결과페이지에 성적과 레벨이 같이 출력되던 것을 분리하고 이를 토대로 성적 Bar UI 적용
  
## 🔍 관련 이슈  
- 이 PR이 해결하는 이슈: #147   
  
## ✅ 테스트 결과  
- [x] 기능 테스트 완료  
- [x] 버그 테스트 완료  
  
## 📌 추가 사항  
- <추가로 고려해야 할 사항>